### PR TITLE
Refactor game logs, normalize simValues field

### DIFF
--- a/docs/2.-endpoints/broadcast.md
+++ b/docs/2.-endpoints/broadcast.md
@@ -12,6 +12,7 @@ The endpoint requires the following JSON:
     "clientId": "client1",
     "region": "example_region",
     "actionCode": 0,
+    "messageBody": "Broadcast Example",
     "cost": 0.0,
     "deaths": 0,
     "infected": 0.0,
@@ -31,7 +32,7 @@ In case of success, the reply is a <mark style="color:green;">200 OK</mark>, wit
 
 ```json
 {
-    "Broadcasted": "0|example_region|client1"
+    "Broadcasted": "0|example_region|client1|Broadcast Example"
 }
 ```
 

--- a/docs/2.-endpoints/broadcast.md
+++ b/docs/2.-endpoints/broadcast.md
@@ -12,8 +12,7 @@ The endpoint requires the following JSON:
     "clientId": "client1",
     "region": "example_region",
     "simValues": "[]",
-    "actionCode": 0,
-    "messageBody": "Broadcast Example"
+    "actionCode": 0
 }
 ```
 
@@ -21,7 +20,7 @@ In case of success, the reply is a <mark style="color:green;">200 OK</mark>, wit
 
 ```json
 {
-    "Broadcasted": "0|example_region|client1|Broadcast Example"
+    "Broadcasted": "0|example_region|client1"
 }
 ```
 

--- a/docs/2.-endpoints/broadcast.md
+++ b/docs/2.-endpoints/broadcast.md
@@ -11,8 +11,19 @@ The endpoint requires the following JSON:
     "serverId": "Server_1",
     "clientId": "client1",
     "region": "example_region",
-    "simValues": "[]",
-    "actionCode": 0
+    "actionCode": 0,
+    "cost": 0.0,
+    "deaths": 0,
+    "infected": 0.0,
+    "contactRate": 0.0,
+    "vaccinationRate": 0.0,
+    "budget": 0.0,
+    "populationTotal": 0,
+    "quarantined": 0,
+    "susceptible": 0,
+    "exposed": 0,
+    "hospitalized": 0,
+    "immunized": 0
 }
 ```
 

--- a/src/broadcast_handler.erl
+++ b/src/broadcast_handler.erl
@@ -22,9 +22,9 @@ init(Req0, State) ->
 
 processBody(PostBody, Req0) ->
     case jsone:decode(PostBody, [{object_format, map}]) of
-        % playerId, sessionId, region, {SimulationValues}, actionId, messageBody
-    #{<<"serverId">> := ServerId,<<"simValues">> := SimValues,<<"clientId">> := ClientId, <<"region">> := Region, <<"actionCode">> := ActionId, <<"messageBody">> := Body} ->
-        Message = lists:concat([binary_to_list(ClientId),"|",binary_to_list(SimValues),"|",binary_to_list(Region),"|",integer_to_list(ActionId),"|",binary_to_list(Body)]),
+        % playerId, sessionId, region, {SimulationValues}, actionId
+    #{<<"serverId">> := ServerId,<<"simValues">> := SimValues,<<"clientId">> := ClientId, <<"region">> := Region, <<"actionCode">> := ActionId} ->
+        Message = lists:concat([binary_to_list(ClientId),"|",binary_to_list(SimValues),"|",binary_to_list(Region),"|",integer_to_list(ActionId)]),
         broadcast(list_to_atom(binary_to_list(ServerId)),Message,Req0);
     _ ->
         cowboy_req:reply(400, #{<<"content-type">> => <<"application/json; charset=utf-8">>}, <<"Invalid or missing parameter">>, Req0)

--- a/src/broadcast_handler.erl
+++ b/src/broadcast_handler.erl
@@ -22,12 +22,13 @@ init(Req0, State) ->
 
 processBody(PostBody, Req0) ->
     case jsone:decode(PostBody, [{object_format, map}]) of
-        % playerId, sessionId, region, {SimulationValues}, actionId, cost, deaths, infected, contactRate, vaccinationRate, budget, populationTotal, quarantined, susceptible, exposed, hospitalized, immunized
+        % playerId, sessionId, region, actionId, messageBody, cost, deaths, infected, contactRate, vaccinationRate, budget, populationTotal, quarantined, susceptible, exposed, hospitalized, immunized
     #{
         <<"serverId">> := ServerId,
         <<"clientId">> := ClientId,
         <<"region">> := Region,
         <<"actionCode">> := ActionId,
+        <<"messageBody">> := MessageBody,
         <<"cost">> := Cost,
         <<"deaths">> := Deaths,
         <<"infected">> := Infected,
@@ -42,7 +43,7 @@ processBody(PostBody, Req0) ->
         <<"immunized">> := Immunized
     } ->
         SimValues = #{"cost" => Cost, "deaths" => Deaths, "infected" => Infected, "contactRate" => ContactRate, "vaccinationRate" => VaccinationRate, "budget" => Budget, "populationTotal" => PopulationTotal, "quarantined" => Quarantined, "susceptible" => Susceptible, "exposed" => Exposed, "hospitalized" => Hospitalized, "immunized" => Immunized},
-        Message = lists:concat([binary_to_list(ClientId),"|",binary_to_list(Region),"|",integer_to_list(ActionId)]),
+        Message = lists:concat([binary_to_list(ClientId),"|",binary_to_list(Region),"|",integer_to_list(ActionId),"|",binary_to_list(MessageBody)]),
         broadcast(list_to_atom(binary_to_list(ServerId)),Message,SimValues,Req0);
     _ ->
         cowboy_req:reply(400, #{<<"content-type">> => <<"application/json; charset=utf-8">>}, <<"Invalid or missing parameter">>, Req0)

--- a/src/gameSession.erl
+++ b/src/gameSession.erl
@@ -205,7 +205,7 @@ session_handler(PlayerDetails, Players, SessionId, PlayersOnline, HostId, GameSt
                     throw("Not part of this game");
                 true ->
                     Message_to_publish = lists:concat([ActionId,"|",Region,"|",PlayerId,"|",MessageBody]),
-                    global:send(localDB,{save_msg, SessionId, SimValues, PlayerId, Region, ActionId, MessageBody}),
+                    global:send(localDB,{save_msg, SessionId, SimValues, PlayerId, Region, ActionId}),
                     mqttMessenger:publish(atom_to_list(SessionId),Message_to_publish),
                     Broadcast_handler_pid ! {success, Message_to_publish}
                 end

--- a/src/gameSession.erl
+++ b/src/gameSession.erl
@@ -199,12 +199,12 @@ session_handler(PlayerDetails, Players, SessionId, PlayersOnline, HostId, GameSt
         {broadcast, Message, Broadcast_handler_pid}->
             % PlayerID,City,Action~
             try
-                [PlayerId, SimValues, Region, ActionId, MessageBody] = string:tokens(Message, "|"),
+                [PlayerId, SimValues, Region, ActionId] = string:tokens(Message, "|"),
                 PlayerVerification = lists:member(PlayerId, dict:fetch_keys(Players)),
                 if PlayerVerification == false ->
                     throw("Not part of this game");
                 true ->
-                    Message_to_publish = lists:concat([ActionId,"|",Region,"|",PlayerId,"|",MessageBody]),
+                    Message_to_publish = lists:concat([ActionId,"|",Region,"|",PlayerId]),
                     global:send(localDB,{save_msg, SessionId, SimValues, PlayerId, Region, ActionId}),
                     mqttMessenger:publish(atom_to_list(SessionId),Message_to_publish),
                     Broadcast_handler_pid ! {success, Message_to_publish}

--- a/src/gameSession.erl
+++ b/src/gameSession.erl
@@ -199,12 +199,12 @@ session_handler(PlayerDetails, Players, SessionId, PlayersOnline, HostId, GameSt
         {broadcast, Message, SimValues, Broadcast_handler_pid}->
             % PlayerID,City,Action~
             try
-                [PlayerId, Region, ActionId] = string:tokens(Message, "|"),
+                [PlayerId, Region, ActionId, MessageBody] = string:tokens(Message, "|"),
                 PlayerVerification = lists:member(PlayerId, dict:fetch_keys(Players)),
                 if PlayerVerification == false ->
                     throw("Not part of this game");
                 true ->
-                    Message_to_publish = lists:concat([ActionId,"|",Region,"|",PlayerId]),
+                    Message_to_publish = lists:concat([ActionId,"|",Region,"|",PlayerId,"|",MessageBody]),
                     global:send(localDB,{save_msg, SessionId, SimValues, PlayerId, Region, ActionId}),
                     mqttMessenger:publish(atom_to_list(SessionId),Message_to_publish),
                     Broadcast_handler_pid ! {success, Message_to_publish}

--- a/src/gameSession.erl
+++ b/src/gameSession.erl
@@ -196,10 +196,10 @@ session_handler(PlayerDetails, Players, SessionId, PlayersOnline, HostId, GameSt
                 HandlerId ! _Reason
             end,
             session_handler(PlayerDetails, Players, SessionId, PlayersOnline, HostId, GameState, OnGoing);
-        {broadcast, Message, Broadcast_handler_pid}->
+        {broadcast, Message, SimValues, Broadcast_handler_pid}->
             % PlayerID,City,Action~
             try
-                [PlayerId, SimValues, Region, ActionId] = string:tokens(Message, "|"),
+                [PlayerId, Region, ActionId] = string:tokens(Message, "|"),
                 PlayerVerification = lists:member(PlayerId, dict:fetch_keys(Players)),
                 if PlayerVerification == false ->
                     throw("Not part of this game");

--- a/src/localDB.erl
+++ b/src/localDB.erl
@@ -8,7 +8,27 @@
 -define(SERVER, localDB).
 
 
--record(game_actions, {playerId, sessionId, simValues, region, actionId, creationDay, creationHour}).
+-record(game_actions, {
+  playerId,
+  sessionId,
+  region,
+  actionId,
+  creationDay,
+  creationHour,
+  cost,
+  deaths,
+  infected,
+  contactRate,
+  vaccinationRate,
+  budget,
+  populationTotal,
+  quarantined,
+  susceptible,
+  exposed,
+  hospitalized,
+  immunized 
+}).
+
 -record(game_sessions, {sessionId, gameSessionFile, player1, player2, player3, player4, ended, created_on}).
  % TODO TABELA DE FEEDBACK - FALAR 1º COM DANIELA E LICINIO
 
@@ -102,7 +122,27 @@ db_write_log(GameSessionId, SimValues, PlayerId, Region, ActionId) ->
     {{Year,Month,Day},{Hour,Minute,Second}} = calendar:universal_time(),
     CreationDay = lists:concat([Day,"/",Month,"/",Year]),
     CreationHour = lists:concat([Hour,":",Minute,":",Second]),
-    mnesia:write(#game_actions{playerId=PlayerId, sessionId=GameSessionId, simValues=SimValues, region=Region, actionId=ActionId, creationDay=CreationDay, creationHour=CreationHour})
+    #{"cost" := Cost, "deaths" := Deaths, "infected" := Infected, "contactRate" := ContactRate, "vaccinationRate" := VaccinationRate, "budget" := Budget, "populationTotal" := PopulationTotal, "quarantined" := Quarantined, "susceptible" := Susceptible, "exposed" := Exposed, "hospitalized" := Hospitalized, "immunized" := Immunized} = SimValues,
+    mnesia:write(#game_actions{
+      playerId=PlayerId,
+      sessionId=GameSessionId,
+      region=Region,
+      actionId=ActionId,
+      creationDay=CreationDay,
+      creationHour=CreationHour,
+      cost=Cost,
+      deaths=Deaths,
+      infected=Infected,
+      contactRate=ContactRate,
+      vaccinationRate=VaccinationRate,
+      budget=Budget,
+      populationTotal=PopulationTotal,
+      quarantined=Quarantined,
+      susceptible=Susceptible,
+      exposed=Exposed,
+      hospitalized=Hospitalized,
+      immunized=Immunized
+    })
    
   end,
   case mnesia:transaction(F) of

--- a/src/localDB.erl
+++ b/src/localDB.erl
@@ -81,7 +81,8 @@ db_get_logs(GameSessionId) ->
                         M#game_actions.sessionId =:= GameSessionId]),
     Results = qlc:e(Query),
     lists:map(fun(Msg) -> 
-      lists:concat(["\"",Msg#game_actions.creationDay,"|",Msg#game_actions.creationHour,"|",Msg#game_actions.region,"|Body\":\"",Msg#game_actions.actionId,"|", Msg#game_actions.playerId,"-",Msg#game_actions.region,"\",\n\t\"",Msg#game_actions.creationDay,"|",Msg#game_actions.creationHour,"|",Msg#game_actions.region,"|SimValues\":",Msg#game_actions.simValues])
+      % TODO: Review this, pass SimValues here again for the back office
+      lists:concat(["\"",Msg#game_actions.creationDay,"|",Msg#game_actions.creationHour,"|",Msg#game_actions.region,"|Body\":\"",Msg#game_actions.actionId,"|", Msg#game_actions.playerId,"-",Msg#game_actions.region,"\",\n\t\"",Msg#game_actions.creationDay,"|",Msg#game_actions.creationHour,"|",Msg#game_actions.region])
       end, 
       Results)
   end,
@@ -96,7 +97,26 @@ db_get_logs() ->
     Query = qlc:q([M || M <- mnesia:table(game_actions)]),
     Results = qlc:e(Query),
     lists:map(fun(Msg) -> 
-      lists:concat([Msg#game_actions.creationDay,",",Msg#game_actions.creationHour,",",Msg#game_actions.sessionId,",",Msg#game_actions.playerId,",", Msg#game_actions.region,",",Msg#game_actions.actionId,",",Msg#game_actions.simValues])
+      lists:concat([
+        Msg#game_actions.creationDay,",",
+        Msg#game_actions.creationHour,",",
+        Msg#game_actions.sessionId,",",
+        Msg#game_actions.playerId,",",
+        Msg#game_actions.region,",",
+        Msg#game_actions.actionId,",",
+        Msg#game_actions.cost,",",
+        Msg#game_actions.deaths,",",
+        Msg#game_actions.infected,",",
+        Msg#game_actions.contactRate,",",
+        Msg#game_actions.vaccinationRate,",",
+        Msg#game_actions.budget,",",
+        Msg#game_actions.populationTotal,",",
+        Msg#game_actions.quarantined,",",
+        Msg#game_actions.susceptible,",",
+        Msg#game_actions.exposed,",",
+        Msg#game_actions.hospitalized,",",
+        Msg#game_actions.immunized
+      ])
       end, 
       Results)
   end,
@@ -275,7 +295,26 @@ export_logs() ->
   {ok, FilePath} = application:get_env(gateway, log_file_path),
   {ok, Device} = file:open(FilePath, [write]),
 
-  Headers = string:join(["Day", "Hour", "Server", "Player", "Region", "ActionId", "Simulation Values"],","),
+  Headers = string:join([
+    "Day",
+    "Hour",
+    "Server",
+    "Player",
+    "Region",
+    "ActionId",
+    "Cost",
+    "Deaths",
+    "Infected",
+    "ContactRate",
+    "VaccinationRate",
+    "Budget",
+    "PopulationTotal",
+    "Quarantined",
+    "Susceptible",
+    "Exposed",
+    "Hospitalized",
+    "Immunized"    
+  ],","),
   io:format(Device, "~s~n", [Headers]),
   write_csv(Device, RawData),
   file:close(Device).
@@ -290,7 +329,26 @@ export_logs_between_dates(DateString, EndDateString) ->
                   ]),
     Results = qlc:eval(Query),
     lists:map(fun(Msg) -> 
-      lists:concat([Msg#game_actions.creationDay,",",Msg#game_actions.creationHour,",",Msg#game_actions.sessionId,",",Msg#game_actions.playerId,",", Msg#game_actions.region,",",Msg#game_actions.actionId,",",Msg#game_actions.simValues])
+      lists:concat([
+        Msg#game_actions.creationDay,",",
+        Msg#game_actions.creationHour,",",
+        Msg#game_actions.sessionId,",",
+        Msg#game_actions.playerId,",",
+        Msg#game_actions.region,",",
+        Msg#game_actions.actionId,",",
+        Msg#game_actions.cost,",",
+        Msg#game_actions.deaths,",",
+        Msg#game_actions.infected,",",
+        Msg#game_actions.contactRate,",",
+        Msg#game_actions.vaccinationRate,",",
+        Msg#game_actions.budget,",",
+        Msg#game_actions.populationTotal,",",
+        Msg#game_actions.quarantined,",",
+        Msg#game_actions.susceptible,",",
+        Msg#game_actions.exposed,",",
+        Msg#game_actions.hospitalized,",",
+        Msg#game_actions.immunized
+      ])
       end, 
       Results)
   end,
@@ -299,7 +357,27 @@ export_logs_between_dates(DateString, EndDateString) ->
       Path = lists:concat(["./logs_",utils:format_date_string_without_slashes(DateString),"_to_",utils:format_date_string_without_slashes(EndDateString),".csv"]),
       {ok, Device} = file:open(Path, [write]),
 
-      Headers = string:join(["Day", "Hour", "Server", "Player", "Region", "ActionId", "Body", "Simulation Values"],","),
+      Headers = string:join([
+        "Day",
+        "Hour",
+        "Server",
+        "Player",
+        "Region",
+        "ActionId",
+        "Body",
+        "Cost",
+        "Deaths",
+        "Infected",
+        "ContactRate",
+        "VaccinationRate",
+        "Budget",
+        "PopulationTotal",
+        "Quarantined",
+        "Susceptible",
+        "Exposed",
+        "Hospitalized",
+        "Immunized"
+      ],","),
       io:format(Device, "~s~n", [Headers]),
       write_csv(Device, Value),
       file:close(Device);


### PR DESCRIPTION
Refactor game actions logging as discussed/proposed.

- [x] Remove message body from game logs (but keep it in the broadcast payload)
- [x] Normalize simValues field from a serialized JSON string to proper fields on the game actions record/mnesia DB, etc.
- [x] 💥 **ERROR:** Broadcast **with empty body message** is crashing the server.
- [ ] ~~Refactor/fix Back Office export to consider new simulation values data structure~~ Won't do for now, it will take time and better to deploy the remaining refactor.
